### PR TITLE
External Event Loader

### DIFF
--- a/AutoEvent-NWApi/AutoEvent.csproj
+++ b/AutoEvent-NWApi/AutoEvent.csproj
@@ -207,6 +207,7 @@
     <Compile Include="Games\ZombieEscape\Plugin.cs" />
     <Compile Include="Interfaces\Event.cs" />
     <Compile Include="Interfaces\IEvent.cs" />
+    <Compile Include="Loader.cs" />
     <Compile Include="Patches\LockerInteract.cs" />
     <Compile Include="Patches\HandCuff.cs" />
     <Compile Include="Patches\CassieScp.cs" />

--- a/AutoEvent-NWApi/AutoEvent.csproj
+++ b/AutoEvent-NWApi/AutoEvent.csproj
@@ -37,38 +37,20 @@
     <WarningLevel>4</WarningLevel>
     <LangVersion>default</LangVersion>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp-Publicized">
-      <HintPath>..\..\..\..\..\OneDrive\Документы\DLLs Library\2\Assembly-CSharp-Publicized.dll</HintPath>
-    </Reference>
-    <Reference Include="Mirror, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\Рабочий стол\файлы\Mirror.dll</HintPath>
-    </Reference>
+  <ItemGroup>    
+    <Reference Include="Assembly-CSharp-Publicized" HintPath="$(SL_REFERENCES)\Assembly-CSharp-Publicized.dll" />
+    <Reference Include="Mirror" HintPath="$(SL_REFERENCES)\Mirror.dll" />
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NVorbis">
-      <HintPath>C:\Users\Roman\AppData\Roaming\SCP Secret Laboratory\PluginAPI\plugins\global\dependencies\NVorbis.dll</HintPath>
-    </Reference>
-    <Reference Include="PluginAPI, Version=13.1.0.0, Culture=neutral, processorArchitecture=AMD64">
+    <Reference Include="PluginAPI, Version=13.1.0.0, Culture=neutral, processorArchitecture=Amd64">
       <HintPath>packages\Northwood.PluginAPI.13.1.0\lib\net48\PluginAPI.dll</HintPath>
     </Reference>
-    <Reference Include="SCPSLAudioApi, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Users\Roman\AppData\Roaming\SCP Secret Laboratory\PluginAPI\plugins\global\dependencies\SCPSLAudioApi.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\OneDrive\Документы\DLLs Library\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AssetBundleModule">
-      <HintPath>..\..\..\..\Рабочий стол\файлы\UnityEngine.AssetBundleModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\OneDrive\Документы\DLLs Library\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
+    <Reference Include="SCPSLAudioApi" HintPath="$(OTHER_REFERENCES)\SCPSLAudioApi.dll" />
+    <Reference Include="System" />    
+    <Reference Include="UnityEngine" HintPath="$(SL_REFERENCES)\UnityEngine.dll" />
+    <Reference Include="UnityEngine.AssetBundleModule" HintPath="$(SL_REFERENCES)\UnityEngine.AssetBundleModule.dll" />
+    <Reference Include="UnityEngine.CoreModule" HintPath="$(SL_REFERENCES)\UnityEngine.CoreModule.dll" />
     <Reference Include="UnityEngine.UnityWebRequestModule" HintPath="$(UNITY_REFERENCES)\UnityEngine.UnityWebRequestModule.dll" />
     <Reference Include="UnityEngine.AnimationModule" HintPath="$(UNITY_REFERENCES)\UnityEngine.AnimationModule.dll" />
     <Reference Include="UnityEngine.PhysicsModule" HintPath="$(UNITY_REFERENCES)\UnityEngine.PhysicsModule.dll" />
@@ -245,6 +227,9 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Translation.cs" />
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/AutoEvent-NWApi/Interfaces/Event.cs
+++ b/AutoEvent-NWApi/Interfaces/Event.cs
@@ -20,11 +20,13 @@ namespace AutoEvent.Interfaces
         /// This prevents double-loading your plugin assembly.
         /// </summary>
         public virtual bool AutoLoad => true;
+
+        public virtual void RegisterEvent() { }
         public virtual void OnStart() => throw new NotImplementedException("cannot start event because OnStart method has not implemented");
         public virtual void OnStop() => throw new NotImplementedException("cannot start event because OnStop method has not implemented");
         public int Id { get; private set; }
         public static List<Event> Events { get; set; } = new List<Event>();
-
+        
         public static void RegisterEvents()
         {
             Assembly callingAssembly = Assembly.GetCallingAssembly();
@@ -42,6 +44,14 @@ namespace AutoEvent.Interfaces
                         continue;
 
                     ev.Id = Events.Count;
+                    try
+                    {
+                        ev.RegisterEvent();
+                    }
+                    catch (Exception)
+                    {
+                        Log.Warning($"[EventLoader] {ev.Name} encountered an error while registering.");
+                    }
                     Events.Add(ev);
 
                     Log.Info($"[EventLoader] {ev.Name} has been registered!");

--- a/AutoEvent-NWApi/Interfaces/Event.cs
+++ b/AutoEvent-NWApi/Interfaces/Event.cs
@@ -14,6 +14,12 @@ namespace AutoEvent.Interfaces
         public abstract string Author { get; set; }
         public abstract string MapName { get; set; }
         public abstract string CommandName { get; set; }
+        public virtual bool UsesExiled => false;
+        /// <summary>
+        /// If using NwApi or Exiled as the base plugin, set this to false, and manually add your plugin to Event.Events (List[Events]).
+        /// This prevents double-loading your plugin assembly.
+        /// </summary>
+        public virtual bool AutoLoad => true;
         public virtual void OnStart() => throw new NotImplementedException("cannot start event because OnStart method has not implemented");
         public virtual void OnStop() => throw new NotImplementedException("cannot start event because OnStop method has not implemented");
         public int Id { get; private set; }

--- a/AutoEvent-NWApi/Loader.cs
+++ b/AutoEvent-NWApi/Loader.cs
@@ -64,18 +64,32 @@ public class Loader
         Dictionary<Assembly, string> locations = new Dictionary<Assembly, string>();
         foreach (string assemblyPath in Directory.GetFiles(Path.Combine(Paths.GlobalPlugins.Plugins, "Events"), "*.dll"))
         {
-            Assembly assembly = LoadAssembly(assemblyPath);
+            try
+            {
 
-            if (assembly is null)
+                Assembly assembly = LoadAssembly(assemblyPath);
+
+                if (assembly is null)
+                    continue;
+
+                locations[assembly] = assemblyPath;
+            }
+            catch (TargetInvocationException e)
+            {
+                Log.Warning("[ExternalEventLoader] Could not load a plugin. Check to make sure it does not require exiled or that you have exiled installed.");
+                if (Debug)
+                {  
+                    Log.Debug(e.ToString());
+                }
+            }
+            catch (Exception e)
             {
                 if (Debug)
-                {
-                    Log.Debug($"[ExternalEventLoader] Assembly is null.");
+                {  
+                    Log.Debug(e.ToString());
                 }
-                continue;
+                Log.Warning($"[ExternalEventLoader] Could not load a plugin due to an error.");
             }
-
-            locations[assembly] = assemblyPath;
         }
 
         foreach (Assembly assembly in locations.Keys)
@@ -87,27 +101,34 @@ public class Loader
                 List<Event> eventList = CreateEventPlugin(assembly);
                 foreach (Event eventPlugin in eventList)
                 {
-
-                    if (eventPlugin is null)
-                        continue;
-
-                    if (eventPlugin.UsesExiled && !isExiledPresent())
+                    try
                     {
-                        Log.Warning(
-                            $"[ExternalEventLoader] Cannot register plugin {eventPlugin.Name} because it requires exiled to work. Exiled has not loaded yet, or is not present at all.");
-                        continue;
+
+                        if (eventPlugin is null)
+                            continue;
+
+                        if (eventPlugin.UsesExiled && !isExiledPresent())
+                        {
+                            Log.Warning(
+                                $"[ExternalEventLoader] Cannot register plugin {eventPlugin.Name} because it requires exiled to work. Exiled has not loaded yet, or is not present at all.");
+                            continue;
+                        }
+
+                        AssemblyInformationalVersionAttribute attribute =
+                            assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+
+                        if (LogAllPluginsOnRegister || Debug)
+                        {
+                            Log.Info(
+                                $"[ExternalEventLoader] Loaded Event {eventPlugin.Name} by {(eventPlugin.Author is not null ? $"{eventPlugin.Author}" : attribute is not null ? attribute.InformationalVersion : string.Empty)}");
+                        }
+
+                        Events.Add(eventPlugin);
                     }
-
-                    AssemblyInformationalVersionAttribute attribute =
-                        assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-
-                    if (LogAllPluginsOnRegister || Debug)
+                    catch (Exception)
                     {
-                        Log.Info(
-                            $"[ExternalEventLoader] Loaded Event {eventPlugin.Name} by {(eventPlugin.Author is not null ? $"{eventPlugin.Author}" : attribute is not null ? attribute.InformationalVersion : string.Empty)}");
+                        //unused
                     }
-
-                    Events.Add(eventPlugin);
                 }
             }
             catch (Exception)
@@ -152,90 +173,135 @@ public class Loader
         {
             foreach (Type type in assembly.GetTypes())
             {
-                if (type.IsAbstract || type.IsInterface)
+                try
                 {
+                    if (type.IsAbstract || type.IsInterface)
+                    {
+                        if (Debug)
+                        {
+                            Log.Debug(
+                                $"[ExternalEventLoader] \"{type.FullName}\" is an interface or abstract class, skipping.");
+                        }
+
+                        continue;
+                    }
+
+                    if (!IsDerivedFromPlugin(type))
+                    {
+                        if (Debug)
+                        {
+                            Log.Debug(
+                                $"[ExternalEventLoader] \"{type.FullName}\" does not inherit from Event, skipping.");
+                        }
+
+                        continue;
+                    }
+
+
                     if (Debug)
                     {
-                        Log.Debug($"[ExternalEventLoader] \"{type.FullName}\" is an interface or abstract class, skipping.");
+                        Log.Debug($"[ExternalEventLoader] Loading type {type.FullName}");
                     }
-                    continue;
-                }
 
-                if (!IsDerivedFromPlugin(type))
-                {
+                    Event plugin = null;
+
+                    ConstructorInfo constructor = type.GetConstructor(Type.EmptyTypes);
+                    if (constructor is not null)
+                    {
+
+                        if (Debug)
+                        {
+                            Log.Debug("[ExternalEventLoader] Public default constructor found, creating instance...");
+                        }
+
+                        plugin = constructor.Invoke(null) as Event;
+                    }
+                    else
+                    {
+
+                        if (Debug)
+                        {
+                            Log.Debug(
+                                $"[ExternalEventLoader] Constructor wasn't found, searching for a property with the {type.FullName} type...");
+                        }
+
+                        object value = Array
+                            .Find(
+                                type.GetProperties(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public),
+                                property => property.PropertyType == type)?.GetValue(null);
+
+                        if (value is not null)
+                            plugin = value as Event;
+                    }
+
+                    if (plugin is null)
+                    {
+                        Log.Error(
+                            $"[ExternalEventLoader] {type.FullName} is a valid event, but it cannot be instantiated! It either doesn't have a public default constructor without any arguments or a static property of the {type.FullName} type!");
+
+                        continue;
+                    }
+
+
                     if (Debug)
                     {
-                        Log.Debug($"[ExternalEventLoader] \"{type.FullName}\" does not inherit from Event, skipping.");
-                    }
-                    continue;
-                }
-
-                
-                if (Debug)
-                {
-                    Log.Debug($"[ExternalEventLoader] Loading type {type.FullName}");
-                }
-
-                Event plugin = null;
-
-                ConstructorInfo constructor = type.GetConstructor(Type.EmptyTypes);
-                if (constructor is not null)
-                {
-                    
-                    if (Debug)
-                    { 
-                        Log.Debug("[ExternalEventLoader] Public default constructor found, creating instance...");
+                        Log.Debug($"[ExternalEventLoader] Instantiated type {type.FullName}");
                     }
 
-                    plugin = constructor.Invoke(null) as Event;
+                    eventsFound.Add(plugin);
                 }
-                else
+                catch (ReflectionTypeLoadException reflectionTypeLoadException)
                 {
-                    
+                    Log.Warning("[ExternalEventLoader] An external event has failed to load! Ensure that you have Exiled installed, or that all of the plugins don't require Exiled.");
+
                     if (Debug)
                     {
-                        Log.Debug($"[ExternalEventLoader] Constructor wasn't found, searching for a property with the {type.FullName} type...");
+
+                        Log.Error(
+                            $"[ExternalEventLoader] Error while initializing event {assembly.GetName().Name} (at {assembly.Location})! {reflectionTypeLoadException}");
+
+                        foreach (Exception loaderException in reflectionTypeLoadException.LoaderExceptions)
+                        {
+                            Log.Error($"[ExternalEventLoader] {loaderException}");
+                        }
                     }
-
-                    object value = Array
-                        .Find(type.GetProperties(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public),
-                            property => property.PropertyType == type)?.GetValue(null);
-
-                    if (value is not null)
-                        plugin = value as Event;
                 }
-
-                if (plugin is null)
+                catch (Exception exception)
                 {
-                    Log.Error($"[ExternalEventLoader] {type.FullName} is a valid event, but it cannot be instantiated! It either doesn't have a public default constructor without any arguments or a static property of the {type.FullName} type!");
-
-                    continue;
+                    Log.Warning("[ExternalEventLoader] An external event has failed to load! Ensure that you have Exiled installed, or that all of the plugins don't require Exiled.");
+                    if (Debug)
+                    {
+                        Log.Error(
+                            $"[ExternalEventLoader] Error while initializing plugin {assembly.GetName().Name} (at {assembly.Location})! {exception}");
+                    }
                 }
-
-                
-                if (Debug)
-                {
-                    Log.Debug($"[ExternalEventLoader] Instantiated type {type.FullName}");
-                }
-
-                eventsFound.Add(plugin);
             }
             return eventsFound;
         }
         catch (ReflectionTypeLoadException reflectionTypeLoadException)
         {
-            Log.Error(
-                $"[ExternalEventLoader] Error while initializing event {assembly.GetName().Name} (at {assembly.Location})! {reflectionTypeLoadException}");
+            Log.Warning("[ExternalEventLoader] An external event has failed to load! Ensure that you have Exiled installed, or that all of the plugins don't require Exiled.");
 
-            foreach (Exception loaderException in reflectionTypeLoadException.LoaderExceptions)
+            if (Debug)
             {
-                Log.Error($"[ExternalEventLoader] {loaderException}");
+
+                Log.Error(
+                    $"[ExternalEventLoader] Error while initializing event {assembly.GetName().Name} (at {assembly.Location})! {reflectionTypeLoadException}");
+
+                foreach (Exception loaderException in reflectionTypeLoadException.LoaderExceptions)
+                {
+                    Log.Error($"[ExternalEventLoader] {loaderException}");
+                }
             }
         }
         catch (Exception exception)
         {
-            Log.Error(
-                $"[ExternalEventLoader] Error while initializing plugin {assembly.GetName().Name} (at {assembly.Location})! {exception}");
+            Log.Warning("[ExternalEventLoader] An external event has failed to load! Ensure that you have Exiled installed, or that all of the plugins don't require Exiled.");
+            if (Debug)
+            {
+                Log.Error(
+                    $"[ExternalEventLoader] Error while initializing plugin {assembly.GetName().Name} (at {assembly.Location})! {exception}");
+            }
         }
 
         return eventsFound;

--- a/AutoEvent-NWApi/Loader.cs
+++ b/AutoEvent-NWApi/Loader.cs
@@ -1,0 +1,366 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Reflection;
+using AutoEvent.Interfaces;
+using PluginAPI.Helpers;
+using PluginAPI.Core;
+
+namespace AutoEvent;
+
+public class Loader
+{
+    /// <summary>
+    /// Overrides the Exiled check for the version of the plugin that is exiled exclusive.
+    /// </summary>
+    private const bool IsExiledPlugin = false;
+    
+    /// <summary>
+    /// If enabled, a debug log is output everytime a plugin is loaded. Not necessary for players.
+    /// </summary>
+    private const bool LogAllPluginsOnRegister = false;
+
+    /// <summary>
+    /// Debug logging only
+    /// </summary>
+    private const bool Debug = false;
+    
+    /// <summary>
+    /// Checks to see if exiled is present on this server.
+    /// </summary>
+    /// <returns></returns>
+    private static bool isExiledPresent()
+    {
+        if (IsExiledPlugin)
+        {
+            return true;
+        }
+        foreach (Assembly ass in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (ass.GetName().Name == "Exiled.Loader")
+            {
+                return true;
+            }
+        }
+        return false;
+
+    }   
+    /// <summary>
+    /// Gets plugin dependencies.
+    /// </summary>
+    public static List<Assembly> Dependencies { get; } = new();
+    
+    /// <summary>
+    /// A list of additional events found.
+    /// </summary>
+    public static List<Event> Events = new List<Event>();
+
+    /// <summary>
+    /// Loads all plugins.
+    /// </summary>
+    public static void LoadEvents()
+    {
+        Dictionary<Assembly, string> locations = new Dictionary<Assembly, string>();
+        foreach (string assemblyPath in Directory.GetFiles(Path.Combine(Paths.GlobalPlugins.Plugins, "Events"), "*.dll"))
+        {
+            Assembly assembly = LoadAssembly(assemblyPath);
+
+            if (assembly is null)
+            {
+                if (Debug)
+                {
+                    Log.Debug($"[ExternalEventLoader] Assembly is null.");
+                }
+                continue;
+            }
+
+            locations[assembly] = assemblyPath;
+        }
+
+        foreach (Assembly assembly in locations.Keys)
+        {
+            
+            try
+            {
+
+                List<Event> eventList = CreateEventPlugin(assembly);
+                foreach (Event eventPlugin in eventList)
+                {
+
+                    if (eventPlugin is null)
+                        continue;
+
+                    if (eventPlugin.UsesExiled && !isExiledPresent())
+                    {
+                        Log.Warning(
+                            $"[ExternalEventLoader] Cannot register plugin {eventPlugin.Name} because it requires exiled to work. Exiled has not loaded yet, or is not present at all.");
+                        continue;
+                    }
+
+                    AssemblyInformationalVersionAttribute attribute =
+                        assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+
+                    if (LogAllPluginsOnRegister || Debug)
+                    {
+                        Log.Info(
+                            $"[ExternalEventLoader] Loaded Event {eventPlugin.Name} by {(eventPlugin.Author is not null ? $"{eventPlugin.Author}" : attribute is not null ? attribute.InformationalVersion : string.Empty)}");
+                    }
+
+                    Events.Add(eventPlugin);
+                }
+            }
+            catch (Exception)
+            {
+                // unused
+            }
+        }
+    }
+
+    /// <summary>
+    /// Loads an assembly.
+    /// </summary>
+    /// <param name="path">The path to load the assembly from.</param>
+    /// <returns>Returns the loaded assembly or <see langword="null"/>.</returns>
+    public static Assembly LoadAssembly(string path)
+    {
+        try
+        {
+            Assembly assembly = Assembly.Load(File.ReadAllBytes(path));
+
+            ResolveAssemblyEmbeddedResources(assembly);
+
+            return assembly;
+        }
+        catch (Exception exception)
+        {
+            Log.Error($"[ExternalEventLoader] Error while loading an assembly at {path}! {exception}");
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Create a plugin instance.
+    /// </summary>
+    /// <param name="assembly">The event assembly.</param>
+    /// <returns>Returns the created plugin instance or <see langword="null"/>.</returns>
+    public static List<Event> CreateEventPlugin(Assembly assembly)
+    {
+        List<Event> eventsFound = new List<Event>();
+        try
+        {
+            foreach (Type type in assembly.GetTypes())
+            {
+                if (type.IsAbstract || type.IsInterface)
+                {
+                    if (Debug)
+                    {
+                        Log.Debug($"[ExternalEventLoader] \"{type.FullName}\" is an interface or abstract class, skipping.");
+                    }
+                    continue;
+                }
+
+                if (!IsDerivedFromPlugin(type))
+                {
+                    if (Debug)
+                    {
+                        Log.Debug($"[ExternalEventLoader] \"{type.FullName}\" does not inherit from Event, skipping.");
+                    }
+                    continue;
+                }
+
+                
+                if (Debug)
+                {
+                    Log.Debug($"[ExternalEventLoader] Loading type {type.FullName}");
+                }
+
+                Event plugin = null;
+
+                ConstructorInfo constructor = type.GetConstructor(Type.EmptyTypes);
+                if (constructor is not null)
+                {
+                    
+                    if (Debug)
+                    { 
+                        Log.Debug("[ExternalEventLoader] Public default constructor found, creating instance...");
+                    }
+
+                    plugin = constructor.Invoke(null) as Event;
+                }
+                else
+                {
+                    
+                    if (Debug)
+                    {
+                        Log.Debug($"[ExternalEventLoader] Constructor wasn't found, searching for a property with the {type.FullName} type...");
+                    }
+
+                    object value = Array
+                        .Find(type.GetProperties(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public),
+                            property => property.PropertyType == type)?.GetValue(null);
+
+                    if (value is not null)
+                        plugin = value as Event;
+                }
+
+                if (plugin is null)
+                {
+                    Log.Error($"[ExternalEventLoader] {type.FullName} is a valid event, but it cannot be instantiated! It either doesn't have a public default constructor without any arguments or a static property of the {type.FullName} type!");
+
+                    continue;
+                }
+
+                
+                if (Debug)
+                {
+                    Log.Debug($"[ExternalEventLoader] Instantiated type {type.FullName}");
+                }
+
+                eventsFound.Add(plugin);
+            }
+            return eventsFound;
+        }
+        catch (ReflectionTypeLoadException reflectionTypeLoadException)
+        {
+            Log.Error(
+                $"[ExternalEventLoader] Error while initializing event {assembly.GetName().Name} (at {assembly.Location})! {reflectionTypeLoadException}");
+
+            foreach (Exception loaderException in reflectionTypeLoadException.LoaderExceptions)
+            {
+                Log.Error($"[ExternalEventLoader] {loaderException}");
+            }
+        }
+        catch (Exception exception)
+        {
+            Log.Error(
+                $"[ExternalEventLoader] Error while initializing plugin {assembly.GetName().Name} (at {assembly.Location})! {exception}");
+        }
+
+        return eventsFound;
+    }
+    
+    /// <summary>
+    /// Indicates that the passed type is derived from the plugin type.
+    /// </summary>
+    /// <param name="type">Type.</param>
+    /// <returns><see langword="true"/> if passed type is derived from <see cref="Event"/>, otherwise <see langword="false"/>.</returns>
+    private static bool IsDerivedFromPlugin(Type type)
+    {
+        while (type is not null)
+        {
+            type = type.BaseType;
+
+            if (type == typeof(Event))
+                return true;
+            
+            if (type is { IsGenericType: true })
+            {
+                Type genericTypeDef = type.GetGenericTypeDefinition();
+                if (Debug)
+                {
+                    Log.Debug($"[ExternalEventLoader] Generic type {genericTypeDef}");
+                }
+
+                if (genericTypeDef == typeof(Event))
+                    return true;
+            }
+            else if (Debug)
+            {
+                Log.Debug($"[ExternalEventLoader] Not Generic Type {type?.Name}.");
+            }
+        }
+
+        return false;
+    }
+    
+     /// <summary>
+        /// Attempts to load Embedded (compressed) assemblies from specified Assembly.
+        /// </summary>
+        /// <param name="target">Assembly to check for embedded assemblies.</param>
+        private static void ResolveAssemblyEmbeddedResources(Assembly target)
+        {
+            try
+            {
+                
+                if (Debug)
+                {
+                    Log.Debug($"[ExternalEventLoader] Attempting to load embedded resources for {target.FullName}");
+                }
+
+                string[] resourceNames = target.GetManifestResourceNames();
+
+                foreach (string name in resourceNames)
+                {
+                    
+                    if (Debug)
+                    {
+                        Log.Debug($"[ExternalEventLoader] Found resource {name}");
+                    }
+
+                    if (name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    {
+                        using MemoryStream stream = new();
+
+                        
+                        if (Debug)
+                        {
+                            Log.Debug($"[ExternalEventLoader] Loading resource {name}");
+                        }
+
+                        Stream dataStream = target.GetManifestResourceStream(name);
+
+                        if (dataStream == null)
+                        {
+                            Log.Error($"[ExternalEventLoader] Unable to resolve resource {name} Stream was null");
+                            continue;
+                        }
+
+                        dataStream.CopyTo(stream);
+
+                        Dependencies.Add(Assembly.Load(stream.ToArray()));
+
+                        
+                        if (Debug)
+                        {
+                            Log.Debug($"[ExternalEventLoader] Loaded resource {name}");
+                        }
+                    }
+                    else if (name.EndsWith(".dll.compressed", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Stream dataStream = target.GetManifestResourceStream(name);
+
+                        if (dataStream == null)
+                        {
+                            Log.Error($"[ExternalEventLoader] Unable to resolve resource {name} Stream was null");
+                            continue;
+                        }
+
+                        using DeflateStream stream = new(dataStream, CompressionMode.Decompress);
+                        using MemoryStream memStream = new();
+
+                        
+                        if (Debug)
+                        {
+                            Log.Debug($"[ExternalEventLoader] Loading resource {name}");
+                        }
+
+                        stream.CopyTo(memStream);
+
+                        Dependencies.Add(Assembly.Load(memStream.ToArray()));
+
+                        
+                        if (Debug)
+                        {
+                            Log.Debug($"[ExternalEventLoader] Loaded resource {name}");
+                        }
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                Log.Error($"[ExternalEventLoader] Failed to load embedded resources from {target.FullName}: {exception}");
+            }
+        }
+}

--- a/AutoEvent-NWApi/Loader.cs
+++ b/AutoEvent-NWApi/Loader.cs
@@ -114,6 +114,10 @@ public class Loader
                             continue;
                         }
 
+                        if (!eventPlugin.AutoLoad)
+                        {
+                            continue;
+                        }
                         AssemblyInformationalVersionAttribute attribute =
                             assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
 
@@ -123,6 +127,14 @@ public class Loader
                                 $"[ExternalEventLoader] Loaded Event {eventPlugin.Name} by {(eventPlugin.Author is not null ? $"{eventPlugin.Author}" : attribute is not null ? attribute.InformationalVersion : string.Empty)}");
                         }
 
+                        try
+                        {
+                            eventPlugin.RegisterEvent();
+                        }
+                        catch (Exception)
+                        {
+                            Log.Warning($"[EventLoader] {eventPlugin.Name} encountered an error while registering.");
+                        }
                         Events.Add(eventPlugin);
                     }
                     catch (Exception)

--- a/AutoEvent-NWApi/Plugin.cs
+++ b/AutoEvent-NWApi/Plugin.cs
@@ -24,7 +24,7 @@ namespace AutoEvent
         [PluginConfig("configs/translation.yml")]
         public Translation Translation;
 
-        [PluginPriority(LoadPriority.Highest)]
+        [PluginPriority(LoadPriority.Low)]
         [PluginEntryPoint("AutoEvent-NWApi", "8.2.7", "A plugin that allows you to run mini-games.", "KoT0XleB")]
         void OnEnabled()
         {

--- a/AutoEvent-NWApi/Plugin.cs
+++ b/AutoEvent-NWApi/Plugin.cs
@@ -6,6 +6,7 @@ using PluginAPI.Enums;
 using PluginAPI.Helpers;
 using PluginAPI.Events;
 using AutoEvent.Events.Handlers;
+using GameCore;
 using Event = AutoEvent.Interfaces.Event;
 
 namespace AutoEvent
@@ -33,13 +34,23 @@ namespace AutoEvent
             HarmonyPatch = new Harmony("autoevent-nwapi");
             HarmonyPatch.PatchAll();
 
-            Event.RegisterEvents();
             EventManager.RegisterEvents(this);
             SCPSLAudioApi.Startup.SetupDependencies();
 
             eventHandler = new EventHandler();
             Servers.RemoteAdmin += eventHandler.OnRemoteAdmin;
 
+            Event.RegisterEvents();
+            
+            // Load External Events.
+            if (!Directory.Exists(Path.Combine(Paths.GlobalPlugins.Plugins, "Events")))
+            {
+                Directory.CreateDirectory(Path.Combine(Paths.GlobalPlugins.Plugins, "Events"));
+            }
+            Loader.LoadEvents();
+            Event.Events.AddRange(Loader.Events);
+            
+            PluginAPI.Core.Log.Info(Loader.Events.Count > 0 ? $"[ExternalEventLoader] Loaded {Loader.Events.Count} external event{(Loader.Events.Count > 1 ? "s" : "")}." : "No external events were found.");
             if (!Directory.Exists(Path.Combine(Paths.GlobalPlugins.Plugins, "Music")))
             {
                 Directory.CreateDirectory(Path.Combine(Paths.GlobalPlugins.Plugins, "Music"));

--- a/AutoEvent/AutoEvent.csproj
+++ b/AutoEvent/AutoEvent.csproj
@@ -38,17 +38,10 @@
     <LangVersion>default</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp-Publicized">
-      <HintPath>..\..\..\..\..\OneDrive\Документы\DLLs Library\2\Assembly-CSharp-Publicized.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
-    <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\OneDrive\Документы\DLLs Library\UnityEngine.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\OneDrive\Документы\DLLs Library\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
+    <Reference Include="UnityEngine" HintPath="$(SL_REFERENCES)\UnityEngine.dll" />
+    <Reference Include="UnityEngine.CoreModule" HintPath="$(SL_REFERENCES)\UnityEngine.CoreModule.dll" />
+    <Reference Include="Assembly-CSharp-Publicized" HintPath="$(SL_REFERENCES)\Assembly-CSharp-Publicized.dll" />
     <Reference Include="UnityEngine.UnityWebRequestModule" HintPath="$(UNITY_REFERENCES)\UnityEngine.UnityWebRequestModule.dll" />
     <Reference Include="UnityEngine.AnimationModule" HintPath="$(UNITY_REFERENCES)\UnityEngine.AnimationModule.dll" />
     <Reference Include="UnityEngine.PhysicsModule" HintPath="$(UNITY_REFERENCES)\UnityEngine.PhysicsModule.dll" />

--- a/AutoEvent/AutoEvent.csproj
+++ b/AutoEvent/AutoEvent.csproj
@@ -159,6 +159,7 @@
     <Compile Include="Events\Versus\EventHandler.cs" />
     <Compile Include="Interfaces\Event.cs" />
     <Compile Include="Interfaces\IEvent.cs" />
+    <Compile Include="Loader.cs" />
     <Compile Include="Patch\CreatePickupPatch.cs" />
     <Compile Include="Patch\JailBirdPatch.cs" />
     <Compile Include="Patch\RemoteAdminPatch.cs" />

--- a/AutoEvent/Interfaces/Event.cs
+++ b/AutoEvent/Interfaces/Event.cs
@@ -16,6 +16,12 @@ namespace AutoEvent.Interfaces
         public abstract string Author { get; set; }
         public abstract string MapName { get; set; }
         public abstract string CommandName { get; set; }
+        public virtual bool UsesExiled => false;
+        /// <summary>
+        /// If using NwApi or Exiled as the base plugin, set this to false, and manually add your plugin to Event.Events (List[Events]).
+        /// This prevents double-loading your plugin assembly.
+        /// </summary>
+        public virtual bool AutoLoad => true;
         public virtual void OnStart() => throw new NotImplementedException("cannot start event because OnStart method has not implemented");
         public abstract void OnStop();
 

--- a/AutoEvent/Interfaces/Event.cs
+++ b/AutoEvent/Interfaces/Event.cs
@@ -22,6 +22,7 @@ namespace AutoEvent.Interfaces
         /// This prevents double-loading your plugin assembly.
         /// </summary>
         public virtual bool AutoLoad => true;
+        public virtual void RegisterEvent() { }
         public virtual void OnStart() => throw new NotImplementedException("cannot start event because OnStart method has not implemented");
         public abstract void OnStop();
 
@@ -38,6 +39,14 @@ namespace AutoEvent.Interfaces
                     if (Activator.CreateInstance(type) is not Event ev)
                         continue;
                     ev.Id = Events.Count;
+                    try
+                    {
+                        ev.RegisterEvent();
+                    }
+                    catch (Exception)
+                    {
+                        Log.Warn($"[EventLoader] {ev.Name} encountered an error while registering.");
+                    }
                     Events.Add(ev);
                     Log.Info($"[EventLoader] {ev.Name} has been registered !");
                 }

--- a/AutoEvent/Loader.cs
+++ b/AutoEvent/Loader.cs
@@ -118,6 +118,11 @@ public class Loader
                                 $"[ExternalEventLoader] Cannot register plugin {eventPlugin.Name} because it requires exiled to work. Exiled has not loaded yet, or is not present at all.");
                             continue;
                         }
+                        
+                        if (!eventPlugin.AutoLoad)
+                        {
+                            continue;
+                        }
 
                         AssemblyInformationalVersionAttribute attribute =
                             assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
@@ -128,6 +133,14 @@ public class Loader
                                 $"[ExternalEventLoader] Loaded Event {eventPlugin.Name} by {(eventPlugin.Author is not null ? $"{eventPlugin.Author}" : attribute is not null ? attribute.InformationalVersion : string.Empty)}");
                         }
 
+                        try
+                        {
+                            eventPlugin.RegisterEvent();
+                        }
+                        catch (Exception)
+                        {
+                            Log.Warn($"[EventLoader] {eventPlugin.Name} encountered an error while registering.");
+                        }
                         Events.Add(eventPlugin);
                     }
                     catch (Exception e)

--- a/AutoEvent/Loader.cs
+++ b/AutoEvent/Loader.cs
@@ -1,0 +1,353 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Reflection;
+using AutoEvent.Interfaces;
+using Exiled.API.Features;
+using Exiled.API.Interfaces;
+using Exiled.Events.Commands.Reload;
+
+namespace AutoEvent;
+
+public class Loader
+{
+    /// <summary>
+    /// Overrides the Exiled check for the version of the plugin that is exiled exclusive.
+    /// </summary>
+    private const bool IsExiledPlugin = true;
+
+    /// <summary>
+    /// If enabled, a debug log is output everytime a plugin is loaded. Not necessary for players.
+    /// </summary>
+    private const bool LogAllPluginsOnRegister = false;
+    
+    /// <summary>
+    /// Debug logging only
+    /// </summary>
+    private const bool Debug = false;
+    
+    /// <summary>
+    /// Checks to see if exiled is present on this server.
+    /// </summary>
+    /// <returns></returns>
+    private static bool isExiledPresent()
+    {
+        if (IsExiledPlugin)
+        {
+            return true;
+        }
+        foreach (Assembly ass in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (ass.GetName().Name == "Exiled.Loader")
+            {
+                return true;
+            }
+        }
+        return false;
+
+    }    
+
+    /// <summary>
+    /// Gets plugin dependencies.
+    /// </summary>
+    public static List<Assembly> Dependencies { get; } = new();
+    
+    /// <summary>
+    /// A list of additional events found.
+    /// </summary>
+    public static List<Event> Events = new List<Event>();
+
+    /// <summary>
+    /// Loads all plugins.
+    /// </summary>
+    public static void LoadEvents()
+    {
+        Dictionary<Assembly, string> locations = new Dictionary<Assembly, string>();
+        foreach (string assemblyPath in Directory.GetFiles(Path.Combine(Paths.Configs, "Events"), "*.dll"))
+        {
+            Assembly assembly = LoadAssembly(assemblyPath);
+
+            if (assembly is null)
+                continue;
+
+            locations[assembly] = assemblyPath;
+        }
+
+        foreach (Assembly assembly in locations.Keys)
+        {
+            if (locations[assembly].Contains("dependencies"))
+                continue;
+
+            try
+            {
+
+                List<Event> eventList = CreateEventPlugin(assembly);
+
+                foreach (Event eventPlugin in eventList)
+                {
+
+                    if (eventPlugin is null)
+                        continue;
+                    if (eventPlugin.UsesExiled && !isExiledPresent())
+                    {
+                        Log.Warn(
+                            $"[ExternalEventLoader] Cannot register plugin {eventPlugin.Name} because it requires exiled to work. Exiled has not loaded yet, or is not present at all.");
+                        continue;
+                    }
+
+                    AssemblyInformationalVersionAttribute attribute =
+                        assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+
+                    if (LogAllPluginsOnRegister || Debug)
+                    {
+                        Log.Info(
+                            $"[ExternalEventLoader] Loaded Event {eventPlugin.Name} by {(eventPlugin.Author is not null ? $"{eventPlugin.Author}" : attribute is not null ? attribute.InformationalVersion : string.Empty)}");
+                    }
+
+                    Events.Add(eventPlugin);
+                }
+            }
+            catch (Exception)
+            {
+                // unused
+            }
+        }
+    }
+
+    /// <summary>
+    /// Loads an assembly.
+    /// </summary>
+    /// <param name="path">The path to load the assembly from.</param>
+    /// <returns>Returns the loaded assembly or <see langword="null"/>.</returns>
+    public static Assembly LoadAssembly(string path)
+    {
+        try
+        {
+            Assembly assembly = Assembly.Load(File.ReadAllBytes(path));
+
+            ResolveAssemblyEmbeddedResources(assembly);
+
+            return assembly;
+        }
+        catch (Exception exception)
+        {
+            Log.Error($"[ExternalEventLoader] Error while loading an assembly at {path}! {exception}");
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Create a plugin instance.
+    /// </summary>
+    /// <param name="assembly">The event assembly.</param>
+    /// <returns>Returns the created plugin instance or <see langword="null"/>.</returns>
+    public static List<Event> CreateEventPlugin(Assembly assembly)
+    {
+        List<Event> eventsFound = new List<Event>();
+        try
+        {
+            foreach (Type type in assembly.GetTypes())
+            {
+                if (type.IsAbstract || type.IsInterface)
+                {
+                    if (Debug)
+                    {
+                       Log.Debug($"[ExternalEventLoader] \"{type.FullName}\" is an interface or abstract class, skipping.");
+                    }
+                    
+                    
+                    continue;
+                }
+
+                if (!IsDerivedFromPlugin(type))
+                {
+                    if (Debug)
+                    {
+                        Log.Debug($"[ExternalEventLoader] \"{type.FullName}\" does not inherit from Event, skipping.");
+                    }
+                    continue;
+                }
+
+                if (Debug)
+                {
+                    Log.Debug($"[ExternalEventLoader] Loading type {type.FullName}");
+                }
+
+                Event plugin = null;
+
+                ConstructorInfo constructor = type.GetConstructor(Type.EmptyTypes);
+                if (constructor is not null)
+                {
+                    if (Debug)
+                    {
+                        Log.Debug("[ExternalEventLoader] Public default constructor found, creating instance...");
+                    }
+
+                    plugin = constructor.Invoke(null) as Event;
+                }
+                else
+                {
+                    if (Debug)
+                    {
+                        Log.Debug($"[ExternalEventLoader] Constructor wasn't found, searching for a property with the {type.FullName} type...");
+                    }
+
+                    object value = Array
+                        .Find(type.GetProperties(BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public),
+                            property => property.PropertyType == type)?.GetValue(null);
+
+                    if (value is not null)
+                        plugin = value as Event;
+                }
+
+                if (plugin is null)
+                {
+                    Log.Error($"[ExternalEventLoader] {type.FullName} is a valid event, but it cannot be instantiated! It either doesn't have a public default constructor without any arguments or a static property of the {type.FullName} type!");
+
+                    continue;
+                }
+
+                if (Debug)
+                {
+                    Log.Debug($"[ExternalEventLoader] Instantiated type {type.FullName}");
+                }
+
+                eventsFound.Add(plugin);
+            }
+            return eventsFound;
+        }
+        catch (ReflectionTypeLoadException reflectionTypeLoadException)
+        {
+            Log.Error(
+                $"[ExternalEventLoader] Error while initializing event {assembly.GetName().Name} (at {assembly.Location})! {reflectionTypeLoadException}");
+
+            foreach (Exception loaderException in reflectionTypeLoadException.LoaderExceptions)
+            {
+                Log.Error(loaderException);
+            }
+        }
+        catch (Exception exception)
+        {
+            Log.Error(
+                $"[ExternalEventLoader] Error while initializing plugin {assembly.GetName().Name} (at {assembly.Location})! {exception}");
+        }
+
+        return eventsFound;
+    }
+    
+    /// <summary>
+    /// Indicates that the passed type is derived from the plugin type.
+    /// </summary>
+    /// <param name="type">Type.</param>
+    /// <returns><see langword="true"/> if passed type is derived from <see cref="Event"/>, otherwise <see langword="false"/>.</returns>
+    private static bool IsDerivedFromPlugin(Type type)
+    {
+        while (type is not null)
+        {
+            type = type.BaseType;
+
+            if (type == typeof(Event))
+                return true;
+            
+            if (type is { IsGenericType: true })
+            {
+                Type genericTypeDef = type.GetGenericTypeDefinition();
+                if (Debug)
+                {
+                    Log.Debug($"[ExternalEventLoader] Generic type {genericTypeDef}");
+                }
+
+                if (genericTypeDef == typeof(Event))
+                    return true;
+            }
+            else if (Debug)
+            {
+                Log.Debug($"[ExternalEventLoader] Not Generic Type {type?.Name}.");
+            }
+        }
+
+        return false;
+    }
+    
+     /// <summary>
+        /// Attempts to load Embedded (compressed) assemblies from specified Assembly.
+        /// </summary>
+        /// <param name="target">Assembly to check for embedded assemblies.</param>
+        private static void ResolveAssemblyEmbeddedResources(Assembly target)
+        {
+            try
+            {
+                if (Debug)
+                {
+                    Log.Debug($"[ExternalEventLoader] Attempting to load embedded resources for {target.FullName}");
+                }
+
+                string[] resourceNames = target.GetManifestResourceNames();
+
+                foreach (string name in resourceNames)
+                {
+                    if (Debug)
+                    {
+                        Log.Debug($"[ExternalEventLoader] Found resource {name}");
+                    }
+
+                    if (name.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                    {
+                        using MemoryStream stream = new();
+
+                        // Log.Debug($"[ExternalEventLoader] Loading resource {name}");
+
+                        Stream dataStream = target.GetManifestResourceStream(name);
+
+                        if (dataStream == null)
+                        {
+                            Log.Error($"[ExternalEventLoader] Unable to resolve resource {name} Stream was null");
+                            continue;
+                        }
+
+                        dataStream.CopyTo(stream);
+
+                        Dependencies.Add(Assembly.Load(stream.ToArray()));
+
+                        if (Debug)
+                        {
+                            Log.Debug($"[ExternalEventLoader] Loaded resource {name}");
+                        }
+                    }
+                    else if (name.EndsWith(".dll.compressed", StringComparison.OrdinalIgnoreCase))
+                    {
+                        Stream dataStream = target.GetManifestResourceStream(name);
+
+                        if (dataStream == null)
+                        {
+                            Log.Error($"[ExternalEventLoader] Unable to resolve resource {name} Stream was null");
+                            continue;
+                        }
+
+                        using DeflateStream stream = new(dataStream, CompressionMode.Decompress);
+                        using MemoryStream memStream = new();
+
+                        if (Debug)
+                        {
+                            Log.Debug($"[ExternalEventLoader] Loading resource {name}");
+                        }
+
+                        stream.CopyTo(memStream);
+
+                        Dependencies.Add(Assembly.Load(memStream.ToArray()));
+
+                        if (Debug)
+                        {
+                            Log.Debug($"[ExternalEventLoader] Loaded resource {name}");
+                        }
+                    }
+                }
+            }
+            catch (Exception exception)
+            {
+                Log.Error($"[ExternalEventLoader] Failed to load embedded resources from {target.FullName}: {exception}");
+            }
+        }
+}

--- a/AutoEvent/Plugin.cs
+++ b/AutoEvent/Plugin.cs
@@ -23,11 +23,17 @@ namespace AutoEvent
             HarmonyPatch = new Harmony("autoevent");
             HarmonyPatch.PatchAll();
             Event.RegisterEvents();
+            
+            // Load External Events.
+            if (!Directory.Exists(Path.Combine(Paths.Configs, "Events"))) Directory.CreateDirectory(Path.Combine(Paths.Configs, "Events"));
+            Loader.LoadEvents();
+            Event.Events.AddRange(Loader.Events);
+            Log.Info(Loader.Events.Count > 0 ? $"[ExternalEventLoader] Loaded {Loader.Events.Count} external event{(Loader.Events.Count > 1 ? "s" : "")}." : "No external events were found.");
 
             if (!Config.IsEnabled) return;
 
             if (!Directory.Exists(Path.Combine(Paths.Configs, "Music"))) Directory.CreateDirectory(Path.Combine(Paths.Configs, "Music"));
-
+            
             Exiled.Events.Handlers.Server.RestartingRound += OnRestarting;
             Exiled.Events.Handlers.Map.Decontaminating += OnDecontamination;
             base.OnEnabled();


### PR DESCRIPTION
# External Event Loader
This PR adds an external event folder and loader. This PR is Non - Breaking, and the plugin will run without any changes. It has also been tested on both Exiled, and NWApi Servers.

What it does:
- Creates a new "Events" folder, that can be used for more events.
- Loads and Instantiates any classes that inherit the main Event abstract class.
- Registers any events found in any .dll files in the new "Events" folder
- Adds an option for events indicating whether they require Exiled.
- Adds an option for events to indicate that the external event loader shouldn't register the event.
    - This allows for event developers to create whole plugins via Exiled / NWApi, and self register events.
- Adds a virtual method for events to use when they are being registered.
    - This allows for event developers to run various tasks when the event is registered.
    - Exiled events shouldn't use code in the constructor to prevent type exceptions. The EventRegistered method is a workaround method that can be used to prevent any issues from arising.

Why is this necessary:
- This makes it much easier for developers to create plugins with this plugin. 
- It enables developers to create events without having to create a full Exiled / NWApi plugin, which can be very time intensive.
- It allows developers to still hook Exiled, and NWApi.
- It allows modular events, that allows server owners to easily and quickly add plugins they like.
- Allows developers to use either NWApi / Exiled, regardless of what version the base AutoEvent plugin is.
    - Exiled plugins will only register if exiled is present. This works regardless of whether the plugin is NWApi or Exiled.
    - Plugins that require Exiled can mark that they require exiled. (This may work better as an attribute but I can look at that later)
- These changes have been tested with both Exiled and NWApi.

What Changes:
- Minor changes to the Event class (non-breaking).
- A new class for an autoloader. (Originally from exiled source code, but modified for this plugin.)
- A minor amount of code added to main plugin class to bootstrap the autoloader.
- Fixes some exposed dependency code (See PR #30)
- NWApi plugin priority is changed to "Low" to allow Exiled to load before any events, so exiled plugins can hook to exiled.

Contact redforce04 on Discord for more details / any questions, or reply here.